### PR TITLE
fix bug: 工单流转编辑页，原状态、目的状态，初始化前没有清空，导致n次打开编辑页，就呈现n组备选项

### DIFF
--- a/static/dist/js/workflow/workflow_manage_edit.js
+++ b/static/dist/js/workflow/workflow_manage_edit.js
@@ -27,9 +27,11 @@
           data: param,  //传入组装的参数
           dataType: "json",
           success: function (result) {
+              $("#sourceStateId").empty();
               result.data.value.map(function (currentValue, index, arr) {
                   $("#sourceStateId").append("<option value=" + "'" + currentValue.id + "'" + ">" + currentValue.name + "</option>");
               })
+              $("#destinationStateId").empty();
               result.data.value.map(function (currentValue, index, arr) {
                   $("#destinationStateId").append("<option value=" + "'" + currentValue.id + "'" + ">" + currentValue.name + "</option>");
               })


### PR DESCRIPTION
fix bug: 工单流转编辑页，原状态、目的状态，初始化前没有清空，导致n次打开编辑页，就呈现n组备选项