### PR TITLE
改善获取多人类型工单列表接口的性能

### DIFF
--- a/service/account/account_base_service.py
+++ b/service/account/account_base_service.py
@@ -43,6 +43,19 @@ class AccountBaseService(BaseService):
 
     @classmethod
     @auto_log
+    def get_user_list_by_usernames(cls, usernames: list)->tuple:
+        """
+        get user info by username
+        :return:
+        """
+        result = LoonUser.objects.filter(username__in=usernames, is_deleted=0).all()
+        if result:
+            return True, result
+        else:
+            return False, 'usernames: {} is not existed or has been deleted'.format(usernames)
+
+    @classmethod
+    @auto_log
     def get_user_by_user_id(cls, user_id: int)->tuple:
         """
         get user by user id

--- a/service/ticket/ticket_base_service.py
+++ b/service/ticket/ticket_base_service.py
@@ -812,17 +812,19 @@ class TicketBaseService(BaseService):
                 participant_alias = participant
         elif participant_type_id == constant_service_ins.PARTICIPANT_TYPE_MULTI:
             participant_type_name = '多人'
-            # 依次获取人员信息
             participant_name_list = participant_name.split(',')
-            participant_alias_list = []
-            for participant_name0 in participant_name_list:
-                flag, participant_user_obj = account_base_service_ins.get_user_by_username(participant_name0)
-                if flag:
-                    participant_alias_list.append(participant_user_obj.alias)
-                else:
-                    participant_alias_list.append(participant_name0)
+            participant_map = {"name": set(), "alias": set()}
+            flag, participant_user_objs = account_base_service_ins.get_user_list_by_usernames(participant_name_list)
+            if flag:
+                for participant_user in participant_user_objs:
+                    participant_map["name"].add(participant_user.name)
+                    participant_map["alias"].add(participant_user.alias)
 
-            participant_alias = ','.join(participant_alias_list)
+                participant_map["alias"].update(
+                    set(participant_name_list) - participant_map["name"]
+                )
+
+            participant_alias = ','.join(participant_map["alias"])
 
         elif participant_type_id == constant_service_ins.PARTICIPANT_TYPE_DEPT:
             participant_type_name = '部门'

--- a/service/ticket/ticket_base_service.py
+++ b/service/ticket/ticket_base_service.py
@@ -817,7 +817,7 @@ class TicketBaseService(BaseService):
             flag, participant_user_objs = account_base_service_ins.get_user_list_by_usernames(participant_name_list)
             if flag:
                 for participant_user in participant_user_objs:
-                    participant_map["name"].add(participant_user.name)
+                    participant_map["name"].add(participant_user.username)
                     participant_map["alias"].add(participant_user.alias)
 
                 participant_map["alias"].update(


### PR DESCRIPTION
多人工单获取人员名字的时候，是一个一个查数据库获取的，性能不是很好，我改成了批量获取的方式。
我这里的场景，原本请求工单列表需要2秒左右，改成批量后需要0.6秒左右。