### PR TITLE
'@Ant-design/charts' version is fixed at 1.1.19

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "not ie <= 10"
   ],
   "dependencies": {
-    "@ant-design/charts": "^1.1.9",
+    "@ant-design/charts": "1.1.9",
     "@ant-design/icons": "^4.0.0",
     "@ant-design/pro-layout": "^6.2.5",
     "@ant-design/pro-table": "^2.4.0",


### PR DESCRIPTION
@ant-design/charts 最新版本(1.3.2)与版本 1.1.9不兼容(1.3.2 没有导出组件 DagreGraph， 导致流程图页面报错)，因此需要固定@ant-design/charts的版本为1.1.9即可