### PR TITLE
对workflow的display_form_str字段没有值的时候的处理

### DIFF
--- a/service/ticket/ticket_base_service.py
+++ b/service/ticket/ticket_base_service.py
@@ -673,7 +673,7 @@ class TicketBaseService(BaseService):
         else:
             # only read permission
             flag, workflow_obj = workflow_base_service_ins.get_by_id(workflow_id=ticket_obj.workflow_id)
-            display_form_field_list = json.loads(workflow_obj.display_form_str) if workflow_obj.display_form_str else []
+            display_form_field_list = json.loads(workflow_obj.display_form_str, strict=False) if workflow_obj.display_form_str else []
             for field in field_list:
                 if field['field_key'] in display_form_field_list:
                     new_field_list.append(field)


### PR DESCRIPTION
当查询一个ticket详情的时候，如果ticket所属的workflow的display_form_str字段没有值时，不加strict=False会报错